### PR TITLE
Fixes js-yaml transitive dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -976,9 +976,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "^5.15.0"
   },
   "dependencies": {
-    "js-yaml": "3.13.0"
+    "js-yaml": "3.13.1"
   },
   "devDependencies": {
     "eslint": "5.15.3",


### PR DESCRIPTION
The module `js-yaml` has a high vulnerability patched in version 3.13.1.
Since `eslint-config` repo is used in other projects, it causes problems with its own transitive dependencies.