### PR TITLE
Disable no-new and no-empty-function in test-config

### DIFF
--- a/eslintrc/nodejs-test.yml
+++ b/eslintrc/nodejs-test.yml
@@ -5,6 +5,8 @@ extends: "@moneytree/eslint-config/nodejs"
 rules:
   # See: http://eslint.org/docs/rules/
 
+  no-new: 0
+  no-empty-function: 0
   no-sync: 0
   complexity: 0
   max-lines: 0


### PR DESCRIPTION
`no-new` because:

```js
expect(() => { new Foo(); }).toThrow();
```

`no-empty-function` because:

```js
const fn = () => {};
expect(fn.name).toBe('fn');
```

In general, noops are no stranger to unit tests in my experience.