### PR TITLE
Prohibit "typeof undeclaredvariable"

### DIFF
--- a/eslintrc/nodejs.yml
+++ b/eslintrc/nodejs.yml
@@ -138,7 +138,7 @@ rules:
   no-restricted-globals: 0
   no-shadow: 0
   no-shadow-restricted-names: 2
-  no-undef: 2
+  no-undef: [2, { typeof: true }]
   no-undef-init: 2
   no-undefined: 0
   no-unused-vars: 2


### PR DESCRIPTION
Before, this was correct:

```js
console.log(typeof foo);
```

Now it will be an error if `foo` is undeclared.

https://eslint.org/docs/rules/no-undef#options