### PR TITLE
Fail "npm test" if rules exist that are not explicitly configured.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint:js": "eslint . -c eslintrc/nodejs.yml",
     "lint:yml": "yamllint eslintrc/*.yml",
-    "test": "npm run lint:js && npm run lint:yml",
-    "rules": "eslint-find-rules -du ./eslintrc/nodejs.yml"
+    "rules": "eslint-find-rules -du ./eslintrc/nodejs.yml",
+    "test": "npm run lint:js && npm run lint:yml && npm run rules"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Currently we have 100% rule coverage. I would like to make sure we keep it that way.
If we introduce a new ESLint which has new rules, but we don't cover those new rules, this will make the test-suite fail.