### PR TITLE
Support ESLint 7.1

### DIFF
--- a/eslintrc/javascript.yml
+++ b/eslintrc/javascript.yml
@@ -1,0 +1,285 @@
+# Base JavaScript configuration
+
+env:
+  es6: true
+
+parserOptions:
+  ecmaVersion: 9
+
+rules:
+  # See: http://eslint.org/docs/rules/
+
+  # Possible Errors
+
+  for-direction: 2
+  getter-return: 2
+  no-async-promise-executor: 2
+  no-await-in-loop: 0
+  no-compare-neg-zero: 2
+  no-cond-assign: [2, always]
+  no-console: 2
+  no-constant-condition: [2, { checkLoops: false }]
+  no-control-regex: 2
+  no-debugger: 2
+  no-dupe-args: 2
+  no-dupe-else-if: 2
+  no-dupe-keys: 2
+  no-duplicate-case: 2
+  no-empty-character-class: 2
+  no-empty: 2
+  no-ex-assign: 2
+  no-extra-boolean-cast: 2
+  no-extra-parens: 0
+  no-extra-semi: 2
+  no-func-assign: 2
+  no-import-assign: 2
+  no-inner-declarations: 2
+  no-invalid-regexp: 2
+  no-irregular-whitespace: 2
+  no-loss-of-precision: 2
+  no-misleading-character-class: 2
+  no-obj-calls: 2
+  no-prototype-builtins: 0
+  no-regex-spaces: 2
+  no-setter-return: 2
+  no-sparse-arrays: 2
+  no-template-curly-in-string: 2
+  no-unexpected-multiline: 2
+  no-unreachable: 2
+  no-unsafe-finally: 2
+  no-unsafe-negation: 2
+  no-useless-backreference: 2
+  require-atomic-updates: 1 # warning, because of false positives: https://github.com/eslint/eslint/issues/11899
+  use-isnan: 2
+  valid-typeof: 2
+
+  # Best Practices
+
+  accessor-pairs: 0
+  array-callback-return: 2
+  block-scoped-var: 2
+  class-methods-use-this: 2
+  complexity: [1, 18]
+  consistent-return: 0
+  curly: [2, all]
+  default-case: 0
+  default-case-last: 0
+  default-param-last: 2
+  dot-location: [2, property]
+  dot-notation: 2
+  eqeqeq: 2
+  grouped-accessor-pairs: 2
+  guard-for-in: 2
+  max-classes-per-file: 0
+  no-alert: 2
+  no-caller: 2
+  no-case-declarations: 2
+  no-constructor-return: 2
+  no-div-regex: 0
+  no-else-return: 2
+  no-empty-function: 2
+  no-empty-pattern: 2
+  no-eq-null: 2
+  no-eval: 2
+  no-extend-native: 2
+  no-extra-bind: 2
+  no-extra-label: 2
+  no-fallthrough: 0
+  no-floating-decimal: 2
+  no-global-assign: 2
+  no-implicit-coercion: 2
+  no-implicit-globals: 2
+  no-implied-eval: 2
+  no-invalid-this: 2
+  no-iterator: 2
+  no-labels: [2, { allowLoop: true }]
+  no-lone-blocks: 2
+  no-loop-func: 2
+  no-magic-numbers: 0
+  no-multi-spaces: [2, { ignoreEOLComments: true }]
+  no-multi-str: 2
+  no-new: 2
+  no-new-func: 2
+  no-new-wrappers: 2
+  no-octal: 2
+  no-octal-escape: 2
+  no-param-reassign: 0
+  no-proto: 2
+  no-redeclare: 2
+  no-restricted-properties: 0
+  no-return-assign: 0
+  no-return-await: 0
+  no-script-url: 2
+  no-self-assign: 2
+  no-self-compare: 2
+  no-sequences: 2
+  no-throw-literal: 2
+  no-unmodified-loop-condition: 2
+  no-unused-expressions: 2
+  no-unused-labels: 2
+  no-useless-call: 2
+  no-useless-catch: 2
+  no-useless-concat: 2
+  no-useless-escape: 2
+  no-useless-return: 2
+  no-void: 2
+  no-warning-comments: 1
+  no-with: 2
+  prefer-named-capture-group: 0
+  prefer-promise-reject-errors: 2
+  prefer-regex-literals: 2
+  radix: 2
+  require-await: 2
+  require-unicode-regexp: 0
+  vars-on-top: 0
+  wrap-iife: [2, outside]
+  yoda: 2
+
+  # Strict Mode
+
+  strict: 0
+
+  # Variables
+
+  init-declarations: 0
+  no-delete-var: 2
+  no-label-var: 2
+  no-restricted-globals: 0
+  no-shadow: 0
+  no-shadow-restricted-names: 2
+  no-undef: [2, { typeof: true }]
+  no-undef-init: 2
+  no-undefined: 0
+  no-unused-vars: 2
+  no-use-before-define: 2
+
+  # Stylistic Issues
+
+  array-bracket-newline: 0
+  array-bracket-spacing: [2, never]
+  array-element-newline: 0
+  block-spacing: [2, always]
+  brace-style: [2, "1tbs"]
+  camelcase: [2, { properties: never }]
+  capitalized-comments: 0
+  comma-dangle: [2, never]
+  comma-spacing: [2, { before: false, after: true }]
+  comma-style: [2, last]
+  computed-property-spacing: [2, never]
+  consistent-this: [2, that]
+  eol-last: [2, always]
+  func-call-spacing: [2, never]
+  func-name-matching: 0
+  func-names: 0
+  func-style: [2, declaration, { allowArrowFunctions: true }]
+  function-call-argument-newline: [2, consistent]
+  function-paren-newline: [2, consistent]
+  id-blacklist: 0
+  id-length: 0
+  id-match: 0
+  implicit-arrow-linebreak: [2, beside]
+  indent: [2, 2, { SwitchCase: 1 }]
+  jsx-quotes: [2, prefer-double]
+  key-spacing: [2, { beforeColon: false, afterColon: true, mode: strict }]
+  keyword-spacing: [2, { before: true, after: true }]
+  line-comment-position: 0
+  linebreak-style: [2, unix]
+  lines-around-comment: [2, { beforeBlockComment: true, allowBlockStart: true }]
+  lines-between-class-members: [2, always, { exceptAfterSingleLine: true }]
+  max-depth: [1, 6]
+  max-len: [2, { code: 120, ignoreUrls: true }]
+  max-lines: [1, { max: 1000, skipBlankLines: true, skipComments: true }]
+  max-lines-per-function: [1, 100]
+  max-nested-callbacks: [1, 6]
+  max-params: 0
+  max-statements: 0
+  max-statements-per-line: [2, { max: 1 }]
+  multiline-comment-style: 0
+  multiline-ternary: 0
+  new-cap: 2
+  new-parens: 2
+  newline-per-chained-call: 0
+  no-array-constructor: 0
+  no-bitwise: 0
+  no-continue: 0
+  no-inline-comments: 0
+  no-lonely-if: 2
+  no-mixed-operators: 2
+  no-mixed-spaces-and-tabs: 2
+  no-multi-assign: 0
+  no-multiple-empty-lines: [2, { max: 2, maxEOF: 1, maxBOF: 0 }]
+  no-negated-condition: 2
+  no-nested-ternary: 2
+  no-new-object: 2
+  no-plusplus: 2
+  no-restricted-syntax: [2, WithStatement]
+  no-tabs: 2
+  no-ternary: 0
+  no-trailing-spaces: 2
+  no-underscore-dangle: 0
+  no-unneeded-ternary: 2
+  no-whitespace-before-property: 2
+  nonblock-statement-body-position: 0
+  object-curly-newline: 0
+  object-curly-spacing: [2, always]
+  object-property-newline: 0
+  one-var: 0
+  one-var-declaration-per-line: 0
+  operator-assignment: [2, always]
+  operator-linebreak: [2, after]
+  padded-blocks: [2, never]
+  padding-line-between-statements: 0
+  prefer-exponentiation-operator: 2
+  prefer-object-spread: 2
+  quote-props: [2, as-needed]
+  quotes: [2, single, { avoidEscape: true, allowTemplateLiterals: true }]
+  semi: [2, always]
+  semi-spacing: [2, { before: false, after: true }]
+  semi-style: 2
+  sort-keys: 0
+  sort-vars: 0
+  space-before-blocks: [2, always]
+  space-before-function-paren: [2, { anonymous: always, named: never, asyncArrow: always }]
+  space-in-parens: [2, never]
+  space-infix-ops: 2
+  space-unary-ops: [2, { words: true, nonwords: false }]
+  spaced-comment: [2, always]
+  switch-colon-spacing: 2
+  template-tag-spacing: 2
+  unicode-bom: [2, never]
+  wrap-regex: 0
+
+  # ECMAScript 6
+
+  arrow-body-style: 0
+  arrow-parens: [2, always]
+  arrow-spacing: 2
+  constructor-super: 2
+  generator-star-spacing: 2
+  no-class-assign: 2
+  no-confusing-arrow: 2
+  no-const-assign: 2
+  no-dupe-class-members: 2
+  no-duplicate-imports: 2
+  no-new-symbol: 2
+  no-restricted-exports: 0
+  no-restricted-imports: 0
+  no-this-before-super: 2
+  no-useless-computed-key: 2
+  no-useless-constructor: 2
+  no-useless-rename: 2
+  no-var: 2
+  object-shorthand: 2
+  prefer-arrow-callback: 2
+  prefer-const: 2
+  prefer-destructuring: 0
+  prefer-numeric-literals: 2
+  prefer-rest-params: 2
+  prefer-spread: 2
+  prefer-template: 2
+  require-yield: 2
+  rest-spread-spacing: [2, never]
+  sort-imports: 0
+  symbol-description: 0
+  template-curly-spacing: [2, never]
+  yield-star-spacing: [2, after]

--- a/eslintrc/nodejs-bin.yml
+++ b/eslintrc/nodejs-bin.yml
@@ -1,10 +1,10 @@
 # Specialized Node.js configuration for CLI scripts
 
-extends: "@moneytree/eslint-config/nodejs"
+extends: "./nodejs.yml"
 
 rules:
   # See: http://eslint.org/docs/rules/
 
   no-console: 0
-  no-process-exit: 0
-  no-sync: 0
+  node/no-process-exit: 0
+  node/no-sync: 0

--- a/eslintrc/nodejs-test.yml
+++ b/eslintrc/nodejs-test.yml
@@ -1,13 +1,13 @@
 # Specialized Node.js configuration for unit test scripts
 
-extends: "@moneytree/eslint-config/nodejs"
+extends: "./nodejs.yml"
 
 rules:
   # See: http://eslint.org/docs/rules/
 
   no-new: 0
   no-empty-function: 0
-  no-sync: 0
   complexity: 0
   max-lines: 0
   max-lines-per-function: 0
+  node/no-sync: 0

--- a/eslintrc/nodejs.yml
+++ b/eslintrc/nodejs.yml
@@ -1,296 +1,58 @@
 # Base Node.js configuration
 
+extends: "./javascript.yml"
+
+plugins:
+  - node
+
 env:
-  es6: true
   node: true
 
-parserOptions:
-  ecmaVersion: 9
-
 rules:
-  # See: http://eslint.org/docs/rules/
+  # See: https://github.com/mysticatea/eslint-plugin-node#-rules
 
-  # Possible Errors
+  # Possible errors
 
-  for-direction: 2
-  getter-return: 2
-  no-async-promise-executor: 2
-  no-await-in-loop: 0
-  no-compare-neg-zero: 2
-  no-cond-assign: [2, always]
-  no-console: 2
-  no-constant-condition: [2, { checkLoops: false }]
-  no-control-regex: 2
-  no-debugger: 2
-  no-dupe-args: 2
-  no-dupe-else-if: 2
-  no-dupe-keys: 2
-  no-duplicate-case: 2
-  no-empty-character-class: 2
-  no-empty: 2
-  no-ex-assign: 2
-  no-extra-boolean-cast: 2
-  no-extra-parens: 0
-  no-extra-semi: 2
-  no-func-assign: 2
-  no-import-assign: 2
-  no-inner-declarations: 2
-  no-invalid-regexp: 2
-  no-irregular-whitespace: 2
-  no-misleading-character-class: 2
-  no-obj-calls: 2
-  no-prototype-builtins: 0
-  no-regex-spaces: 2
-  no-setter-return: 2
-  no-sparse-arrays: 2
-  no-template-curly-in-string: 2
-  no-unexpected-multiline: 2
-  no-unreachable: 2
-  no-unsafe-finally: 2
-  no-unsafe-negation: 2
-  require-atomic-updates: 1 # warning, because of false positives: https://github.com/eslint/eslint/issues/11899
-  use-isnan: 2
-  valid-typeof: 2
+  node/handle-callback-err: [2, "^(err|error)$"]
+  node/no-callback-literal: 2
+  node/no-exports-assign: 2
+  node/no-extraneous-import: 2
+  node/no-extraneous-require: 2
+  node/no-missing-import: 2
+  node/no-missing-require: 2
+  node/no-new-require: 2
+  node/no-path-concat: 2
+  node/no-process-exit: 2
+  node/no-unpublished-bin: 2
+  node/no-unpublished-import: 2
+  node/no-unpublished-require: 2
+  node/no-unsupported-features/es-builtins: 0
+  node/no-unsupported-features/es-syntax: 0
+  node/no-unsupported-features/node-builtins: 0
+  node/process-exit-as-throw: 2
+  node/shebang: 0
 
-  # Best Practices
+  # Best practices
 
-  accessor-pairs: 0
-  array-callback-return: 2
-  block-scoped-var: 2
-  class-methods-use-this: 2
-  complexity: [1, 18]
-  consistent-return: 0
-  curly: [2, all]
-  default-case: 0
-  default-param-last: 2
-  dot-location: [2, property]
-  dot-notation: 2
-  eqeqeq: 2
-  grouped-accessor-pairs: 2
-  guard-for-in: 2
-  max-classes-per-file: 0
-  no-alert: 2
-  no-caller: 2
-  no-case-declarations: 2
-  no-constructor-return: 2
-  no-div-regex: 0
-  no-else-return: 2
-  no-empty-function: 2
-  no-empty-pattern: 2
-  no-eq-null: 2
-  no-eval: 2
-  no-extend-native: 2
-  no-extra-bind: 2
-  no-extra-label: 2
-  no-fallthrough: 0
-  no-floating-decimal: 2
-  no-global-assign: 2
-  no-implicit-coercion: 2
-  no-implicit-globals: 2
-  no-implied-eval: 2
-  no-invalid-this: 2
-  no-iterator: 2
-  no-labels: [2, { allowLoop: true }]
-  no-lone-blocks: 2
-  no-loop-func: 2
-  no-magic-numbers: 0
-  no-multi-spaces: [2, { ignoreEOLComments: true }]
-  no-multi-str: 2
-  no-new: 2
-  no-new-func: 2
-  no-new-wrappers: 2
-  no-octal: 2
-  no-octal-escape: 2
-  no-param-reassign: 0
-  no-proto: 2
-  no-redeclare: 2
-  no-restricted-properties: 0
-  no-return-assign: 0
-  no-return-await: 0
-  no-script-url: 2
-  no-self-assign: 2
-  no-self-compare: 2
-  no-sequences: 2
-  no-throw-literal: 2
-  no-unmodified-loop-condition: 2
-  no-unused-expressions: 2
-  no-unused-labels: 2
-  no-useless-call: 2
-  no-useless-catch: 2
-  no-useless-concat: 2
-  no-useless-escape: 2
-  no-useless-return: 2
-  no-void: 2
-  no-warning-comments: 1
-  no-with: 2
-  prefer-named-capture-group: 0   # Supported from Node.js 10
-  prefer-promise-reject-errors: 2
-  prefer-regex-literals: 2
-  radix: 2
-  require-await: 2
-  require-unicode-regexp: 0
-  vars-on-top: 0
-  wrap-iife: [2, outside]
-  yoda: 2
+  node/no-deprecated-api: 0
 
-  # Strict Mode
+  # Stylistic issues
 
-  strict: 0
-
-  # Variables
-
-  init-declarations: 0
-  no-delete-var: 2
-  no-label-var: 2
-  no-restricted-globals: 0
-  no-shadow: 0
-  no-shadow-restricted-names: 2
-  no-undef: [2, { typeof: true }]
-  no-undef-init: 2
-  no-undefined: 0
-  no-unused-vars: 2
-  no-use-before-define: 2
-
-  # Node.js and CommonJS
-
-  callback-return: 2
-  global-require: 0
-  handle-callback-err: [2, "^(err|error)$"]
-  no-buffer-constructor: 2
-  no-mixed-requires: 2
-  no-new-require: 2
-  no-path-concat: 2
-  no-process-env: 0
-  no-process-exit: 2
-  no-restricted-modules: 0
-  no-sync: 2
-
-  # Stylistic Issues
-
-  array-bracket-newline: 0
-  array-bracket-spacing: [2, never]
-  array-element-newline: 0
-  block-spacing: [2, always]
-  brace-style: [2, "1tbs"]
-  camelcase: [2, { properties: never }]
-  capitalized-comments: 0
-  comma-dangle: [2, never]
-  comma-spacing: [2, { before: false, after: true }]
-  comma-style: [2, last]
-  computed-property-spacing: [2, never]
-  consistent-this: [2, that]
-  eol-last: [2, always]
-  func-call-spacing: [2, never]
-  func-name-matching: 0
-  func-names: 0
-  func-style: [2, declaration, { allowArrowFunctions: true }]
-  function-call-argument-newline: [2, consistent]
-  function-paren-newline: [2, consistent]
-  id-blacklist: 0
-  id-length: 0
-  id-match: 0
-  implicit-arrow-linebreak: [2, beside]
-  indent: [2, 2, { SwitchCase: 1 }]
-  jsx-quotes: [2, prefer-double]
-  key-spacing: [2, { beforeColon: false, afterColon: true, mode: strict }]
-  keyword-spacing: [2, { before: true, after: true }]
-  line-comment-position: 0
-  linebreak-style: [2, unix]
-  lines-around-comment: [2, { beforeBlockComment: true, allowBlockStart: true }]
-  lines-between-class-members: [2, always, { exceptAfterSingleLine: true }]
-  max-depth: [1, 6]
-  max-len: [2, { code: 120, ignoreUrls: true }]
-  max-lines: [1, { max: 1000, skipBlankLines: true, skipComments: true }]
-  max-lines-per-function: [1, 100]
-  max-nested-callbacks: [1, 6]
-  max-params: 0
-  max-statements: 0
-  max-statements-per-line: [2, { max: 1 }]
-  multiline-comment-style: 0
-  multiline-ternary: 0
-  new-cap: 2
-  new-parens: 2
-  newline-per-chained-call: 0
-  no-array-constructor: 0
-  no-bitwise: 0
-  no-continue: 0
-  no-inline-comments: 0
-  no-lonely-if: 2
-  no-mixed-operators: 2
-  no-mixed-spaces-and-tabs: 2
-  no-multi-assign: 0
-  no-multiple-empty-lines: [2, { max: 2, maxEOF: 1, maxBOF: 0 }]
-  no-negated-condition: 2
-  no-nested-ternary: 2
-  no-new-object: 2
-  no-plusplus: 2
-  no-restricted-syntax: [2, WithStatement]
-  no-tabs: 2
-  no-ternary: 0
-  no-trailing-spaces: 2
-  no-underscore-dangle: 0
-  no-unneeded-ternary: 2
-  no-whitespace-before-property: 2
-  nonblock-statement-body-position: 0
-  object-curly-newline: 0
-  object-curly-spacing: [2, always]
-  object-property-newline: 0
-  one-var: 0
-  one-var-declaration-per-line: 0
-  operator-assignment: [2, always]
-  operator-linebreak: [2, after]
-  padded-blocks: [2, never]
-  padding-line-between-statements: 0
-  prefer-exponentiation-operator: 2
-  prefer-object-spread: 2
-  quote-props: [2, as-needed]
-  quotes: [2, single, { avoidEscape: true, allowTemplateLiterals: true }]
-  semi: [2, always]
-  semi-spacing: [2, { before: false, after: true }]
-  semi-style: 2
-  sort-keys: 0
-  sort-vars: 0
-  space-before-blocks: [2, always]
-  space-before-function-paren: [2, { anonymous: always, named: never, asyncArrow: always }]
-  space-in-parens: [2, never]
-  space-infix-ops: 2
-  space-unary-ops: [2, { words: true, nonwords: false }]
-  spaced-comment: [2, always]
-  switch-colon-spacing: 2
-  template-tag-spacing: 2
-  unicode-bom: [2, never]
-  wrap-regex: 0
-
-  # ECMAScript 6
-
-  arrow-body-style: 0
-  arrow-parens: [2, always]
-  arrow-spacing: 2
-  constructor-super: 2
-  generator-star-spacing: 2
-  no-class-assign: 2
-  no-confusing-arrow: 2
-  no-const-assign: 2
-  no-dupe-class-members: 2
-  no-duplicate-imports: 2
-  no-new-symbol: 2
-  no-restricted-imports: 0
-  no-this-before-super: 2
-  no-useless-computed-key: 2
-  no-useless-constructor: 2
-  no-useless-rename: 2
-  no-var: 2
-  object-shorthand: 2
-  prefer-arrow-callback: 2
-  prefer-const: 2
-  prefer-destructuring: 0
-  prefer-numeric-literals: 2
-  prefer-rest-params: 2
-  prefer-spread: 2
-  prefer-template: 2
-  require-yield: 2
-  rest-spread-spacing: [2, never]
-  sort-imports: 0
-  symbol-description: 0
-  template-curly-spacing: [2, never]
-  yield-star-spacing: [2, after]
+  node/callback-return: 2
+  node/exports-style: 0
+  node/file-extension-in-import: 0
+  node/global-require: 0
+  node/no-mixed-requires: 2
+  node/no-process-env: 0
+  node/no-restricted-import: 0
+  node/no-restricted-require: 0
+  node/no-sync: 2
+  node/prefer-global/buffer: 2
+  node/prefer-global/console: 2
+  node/prefer-global/process: 2
+  node/prefer-global/text-decoder: 2
+  node/prefer-global/text-encoder: 2
+  node/prefer-global/url-search-params: 2
+  node/prefer-global/url: 2
+  node/prefer-promises/dns: 0
+  node/prefer-promises/fs: 0

--- a/javascript.js
+++ b/javascript.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./scripts/loadConfig')('javascript');

--- a/nodejs-bin.js
+++ b/nodejs-bin.js
@@ -1,12 +1,3 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-
-const filePath = path.join(__dirname, 'eslintrc', 'nodejs-bin.yml');
-
-// eslint-disable-next-line no-sync
-const config = fs.readFileSync(filePath, { encoding: 'utf8' });
-
-module.exports = yaml.safeLoad(config);
+module.exports = require('./scripts/loadConfig')('nodejs-bin');

--- a/nodejs-test.js
+++ b/nodejs-test.js
@@ -1,12 +1,3 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-
-const filePath = path.join(__dirname, 'eslintrc', 'nodejs-test.yml');
-
-// eslint-disable-next-line no-sync
-const config = fs.readFileSync(filePath, { encoding: 'utf8' });
-
-module.exports = yaml.safeLoad(config);
+module.exports = require('./scripts/loadConfig')('nodejs-test');

--- a/nodejs.js
+++ b/nodejs.js
@@ -1,12 +1,3 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const yaml = require('js-yaml');
-
-const filePath = path.join(__dirname, 'eslintrc', 'nodejs.yml');
-
-// eslint-disable-next-line no-sync
-const config = fs.readFileSync(filePath, { encoding: 'utf8' });
-
-module.exports = yaml.safeLoad(config);
+module.exports = require('./scripts/loadConfig')('nodejs');

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,14 +121,12 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -262,8 +260,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -299,23 +296,45 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+      "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -371,22 +390,22 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.1.tgz",
-      "integrity": "sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.1.0.tgz",
+      "integrity": "sha512-DfS3b8iHMK5z/YLSme8K5cge168I8j8o1uiVmFCgnnjxZQbCGyraF8bMl7Ju4yfBmCuxD7shOF7eqGkcuIHfsA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
+        "eslint-utils": "^2.0.0",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "espree": "^7.0.0",
+        "esquery": "^1.2.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
@@ -399,20 +418,71 @@
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
+        "levn": "^0.4.1",
         "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "eslint-find-rules": {
@@ -428,6 +498,40 @@
         "which": "^1.2.8",
         "window-size": "0.3.0",
         "yargs": "^8.0.1"
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
+          "integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "eslint-rule-documentation": {
@@ -447,10 +551,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -458,13 +561,12 @@
     "eslint-visitor-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-      "dev": true
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
     },
     "espree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.0.0.tgz",
+      "integrity": "sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==",
       "dev": true,
       "requires": {
         "acorn": "^7.1.1",
@@ -901,15 +1003,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -1018,13 +1111,13 @@
       }
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "lines-and-columns": {
@@ -1161,7 +1254,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1284,12 +1376,6 @@
         }
       }
     },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1350,17 +1436,17 @@
       "dev": true
     },
     "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "os-locale": {
@@ -1449,8 +1535,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "2.0.0",
@@ -1537,9 +1622,9 @@
       }
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "progress": {
@@ -1582,10 +1667,9 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -1603,7 +1687,6 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -1661,9 +1744,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
       "dev": true
     },
     "semver-compare": {
@@ -1776,34 +1859,15 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        }
       }
     },
     "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^4.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        }
+        "ansi-regex": "^5.0.0"
       }
     },
     "strip-bom": {
@@ -1845,6 +1909,12 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1866,6 +1936,15 @@
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1898,12 +1977,12 @@
       "dev": true
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "^1.2.1"
       }
     },
     "type-fest": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "ESLint shared configuration for Moneytree projects",
   "main": "nodejs.js",
   "scripts": {
-    "lint:js": "eslint . -c eslintrc/nodejs.yml",
+    "lint:js": "eslint . -c eslintrc/nodejs-bin.yml",
     "lint:yml": "yamllint eslintrc/*.yml",
-    "rules": "eslint-find-rules -du ./eslintrc/nodejs.yml",
+    "rules": "./scripts/test-rules.sh",
     "test": "npm run lint:js && npm run lint:yml && npm run rules"
   },
   "husky": {
@@ -18,13 +18,14 @@
   "repository": "github:moneytree/eslint-config",
   "license": "MIT",
   "peerDependencies": {
-    "eslint": "^6.7.0"
+    "eslint": "^7.1.0"
   },
   "dependencies": {
+    "eslint-plugin-node": "11.1.0",
     "js-yaml": "3.14.0"
   },
   "devDependencies": {
-    "eslint": "6.7.1",
+    "eslint": "7.1.0",
     "eslint-find-rules": "3.5.0",
     "husky": "4.2.5",
     "yaml-lint": "1.2.4"

--- a/scripts/loadConfig.js
+++ b/scripts/loadConfig.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+module.exports = (name) => {
+  const filePath = path.join(__dirname, '..', 'eslintrc', `${name}.yml`);
+
+  // eslint-disable-next-line node/no-sync
+  const config = fs.readFileSync(filePath, { encoding: 'utf8' });
+
+  return yaml.safeLoad(config);
+};

--- a/scripts/test-rules.sh
+++ b/scripts/test-rules.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+BIN=$(npm bin)
+EXIT_CODE=0
+
+for FILE in ./eslintrc/*.yml
+do
+  echo
+  echo "*** Testing ${FILE} for deprecated and new rules ***"
+
+  "${BIN}/eslint-find-rules" -du "${FILE}"
+  CODE=$?
+
+  if [[ $CODE != 0 ]]
+  then
+    EXIT_CODE=$CODE
+  fi
+done
+
+echo
+
+if [[ $EXIT_CODE != 0 ]]
+then
+  echo "Failed."
+  echo
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
This will constitute a major version update of eslint-config.

This is the migration guide for ESLint 7: https://eslint.org/docs/user-guide/migrating-to-7.0.0
v7.0.0 and v7.1.0 release notes can be found here: https://eslint.org/blog/

Because ESLint deprecated all Node specific rules, and they all got moved to a dedicated ESLint plugin, that plugin has now become a dependency. The base configuration is now in `javascript.yml`, which is agnostic about the kind of environment it's run in. The `nodejs.yml` file combines javascript.yml and the plugin for Node-rules.